### PR TITLE
Fixed typo in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The plugin adds the following goals:
 * ```mvn tc-sdk:start``` will do the init check (see above), deploy your plugin to the data directory, and start a TeamCity server and agent
 * ```mvn tc-sdk:stop``` will do the init check (once again) and will issue a stop command to both the server and agent.
 * ```mvn tc-sdk:reload``` will do the init check and will copy your plugin to the data directory. Can be useful to quickly deploy agent-side changes without the need to restart the whole server, as TeamCity will automatically update the agent with the new plugin version.
-* ```mvn tc-sdk:reloadResouces``` will do the init check and will copy over your static resources (from <plugin>-server/src/main/resouces/buildServerResources) to target teamcity server. May speedup ui development.
+* ```mvn tc-sdk:reloadResources``` will do the init check and will copy over your static resources (from <plugin>-server/src/main/resouces/buildServerResources) to target teamcity server. May speedup ui development.
 
 Please note that TeamCity startup process is not instant and the stop command sent immediately after the start may not be processed properly.
 


### PR DESCRIPTION
There is a typo in the README.MD file which may throw the below exception to users.

Could not find goal 'reloadResouces' in plugin org.jetbrains.teamcity:teamcity-sdk-maven-plugin:0.2 among available goals start, init, stop, reloadResources, help, reload 