### PR TITLE
Runtime plugins reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ The plugin adds the following goals:
 * ```mvn tc-sdk:init``` will check if TeamCity is available in the target location and its version is the same as used in the maven project. If it is missing, the plugin can download the distribution and unpack it for you.
 * ```mvn tc-sdk:start``` will do the init check (see above), deploy your plugin to the data directory, and start a TeamCity server and agent
 * ```mvn tc-sdk:stop``` will do the init check (once again) and will issue a stop command to both the server and agent.
-* ```mvn tc-sdk:reload``` will do the init check and will copy your plugin to the data directory. Can be useful to quickly deploy agent-side changes without the need to restart the whole server, as TeamCity will automatically update the agent with the new plugin version.
+* ```mvn tc-sdk:reload``` will do the init check and will try to reload the plugin without server restart. If reload is impossible (for TeamCity less then 2018.2 or the plugin not marked as reloadable) then only agent side of the plugin will be reloaded as by the ```tc-sdk:reloadAgent``` task. 
+* ```mvn tc-sdk:reloadAgent``` will do the init check and will copy your plugin to the data directory. Can be useful to quickly deploy agent-side changes without the need to restart the whole server, as TeamCity will automatically update the agent with the new plugin version.
 * ```mvn tc-sdk:reloadResources``` will do the init check and will copy over your static resources (from <plugin>-server/src/main/resouces/buildServerResources) to target teamcity server. May speedup ui development.
 
 Please note that TeamCity startup process is not instant and the stop command sent immediately after the start may not be processed properly.

--- a/src/main/kotlin/org/jetbrains/teamcity/maven/sdk/AbstractTeamCityMojo.kt
+++ b/src/main/kotlin/org/jetbrains/teamcity/maven/sdk/AbstractTeamCityMojo.kt
@@ -200,9 +200,9 @@ public abstract class AbstractTeamCityMojo() : AbstractMojo() {
 
         val authToken = "Basic " + String(Base64.getEncoder().encode("$username:$password".toByteArray(Charset.forName("UTF-8"))))
 
-        val enableAction = getPluginReloadURL(false)
-        log.debug("Sending " + enableAction.toString() + "...")
-        val disableRequest = enableAction.openConnection()
+        val disableAction = getPluginReloadURL(false)
+        log.debug("Sending " + disableAction.toString() + "...")
+        val disableRequest = disableAction.openConnection()
         (disableRequest as HttpURLConnection).requestMethod = "POST"
         disableRequest.setRequestProperty ("Authorization", authToken)
 
@@ -237,9 +237,9 @@ public abstract class AbstractTeamCityMojo() : AbstractMojo() {
 
         uploadPluginAgentZip()
 
-        val disableAction = getPluginReloadURL(true)
-        log.debug("Sending " + disableAction.toString() + "...")
-        val enableRequest = disableAction.openConnection()
+        val enableAction = getPluginReloadURL(true)
+        log.debug("Sending " + enableAction.toString() + "...")
+        val enableRequest = enableAction.openConnection()
         (enableRequest as HttpURLConnection).requestMethod = "POST"
         enableRequest.setRequestProperty ("Authorization", authToken)
         try {

--- a/src/main/kotlin/org/jetbrains/teamcity/maven/sdk/AbstractTeamCityMojo.kt
+++ b/src/main/kotlin/org/jetbrains/teamcity/maven/sdk/AbstractTeamCityMojo.kt
@@ -268,6 +268,16 @@ public abstract class AbstractTeamCityMojo() : AbstractMojo() {
             File(teamcityDir, dataDirectory)
         }
     }
+
+    protected fun isPluginReloadable(): Boolean {
+        val pluginDescriptor = File(project!!.basedir, "teamcity-plugin.xml")
+        if (!pluginDescriptor.exists()) {
+            log.warn("Plugin descriptor wan't found in ${pluginDescriptor.absolutePath}")
+            return false
+        }
+
+        return pluginDescriptor.readText(Charset.forName("UTF-8")).contains("allow-runtime-reload=\"true\"")
+    }
 }
 
 public enum class TCDirectoryState {

--- a/src/main/kotlin/org/jetbrains/teamcity/maven/sdk/AbstractTeamCityMojo.kt
+++ b/src/main/kotlin/org/jetbrains/teamcity/maven/sdk/AbstractTeamCityMojo.kt
@@ -200,9 +200,9 @@ public abstract class AbstractTeamCityMojo() : AbstractMojo() {
 
         val authToken = "Basic " + String(Base64.getEncoder().encode("$username:$password".toByteArray(Charset.forName("UTF-8"))))
 
-        val url = URL("http://$serverAddress/httpAuth/admin/plugins.html?action=setEnabled&enabled=false&pluginPath=%3CTeamCity%20Data%20Directory%3E/plugins/$pluginPackageName")
-        log.debug("Sending " + url.toString() + "...")
-        val disableRequest = url.openConnection()
+        val enableAction = getPluginReloadURL(false)
+        log.debug("Sending " + enableAction.toString() + "...")
+        val disableRequest = enableAction.openConnection()
         (disableRequest as HttpURLConnection).requestMethod = "POST"
         disableRequest.setRequestProperty ("Authorization", authToken)
 
@@ -222,7 +222,7 @@ public abstract class AbstractTeamCityMojo() : AbstractMojo() {
             }
         } catch (ex: ConnectException) {
             log.warn("Cannot find running server on http://$serverAddress. Is server started?")
-            return false;
+            return false
         } catch (ex: IOException) {
             when (disableRequest.responseCode) {
                 401 -> log.warn("Cannot authenticate server on http://$serverAddress with " +
@@ -237,9 +237,9 @@ public abstract class AbstractTeamCityMojo() : AbstractMojo() {
 
         uploadPluginAgentZip()
 
-        val urlDisable = URL("http://$serverAddress/httpAuth/admin/plugins.html?action=setEnabled&enabled=true&pluginPath=%3CTeamCity%20Data%20Directory%3E/plugins/$pluginPackageName")
-        log.debug("Sending " + urlDisable.toString() + "...")
-        val enableRequest = urlDisable.openConnection()
+        val disableAction = getPluginReloadURL(true)
+        log.debug("Sending " + disableAction.toString() + "...")
+        val enableRequest = disableAction.openConnection()
         (enableRequest as HttpURLConnection).requestMethod = "POST"
         enableRequest.setRequestProperty ("Authorization", authToken)
         try {
@@ -260,6 +260,9 @@ public abstract class AbstractTeamCityMojo() : AbstractMojo() {
 
         return true
     }
+
+    private fun getPluginReloadURL(action: Boolean) =
+            URL("http://$serverAddress/httpAuth/admin/plugins.html?action=setEnabled&enabled=$action&pluginPath=%3CTeamCity%20Data%20Directory%3E/plugins/$pluginPackageName")
 
     private fun getDataDir(): File {
         return if (File(dataDirectory).isAbsolute) {

--- a/src/main/kotlin/org/jetbrains/teamcity/maven/sdk/AbstractTeamCityMojo.kt
+++ b/src/main/kotlin/org/jetbrains/teamcity/maven/sdk/AbstractTeamCityMojo.kt
@@ -200,7 +200,7 @@ public abstract class AbstractTeamCityMojo() : AbstractMojo() {
 
         val authToken = "Basic " + String(Base64.getEncoder().encode("$username:$password".toByteArray(Charset.forName("UTF-8"))))
 
-        val url = URL("http://$serverAddress/httpAuth/admin/plugins.html?action=setEnabled&enabled=false&waitUnload=true&pluginPath=%3CTeamCity%20Data%20Directory%3E/plugins/$pluginPackageName")
+        val url = URL("http://$serverAddress/httpAuth/admin/plugins.html?action=setEnabled&enabled=false&pluginPath=%3CTeamCity%20Data%20Directory%3E/plugins/$pluginPackageName")
         log.debug("Sending " + url.toString() + "...")
         val disableRequest = url.openConnection()
         (disableRequest as HttpURLConnection).requestMethod = "POST"

--- a/src/main/kotlin/org/jetbrains/teamcity/maven/sdk/TeamCitySDK.kt
+++ b/src/main/kotlin/org/jetbrains/teamcity/maven/sdk/TeamCitySDK.kt
@@ -94,13 +94,13 @@ public class ReloadPluginMojo() : AbstractTeamCityMojo() {
 @Mojo(name = "reload", aggregator = true)
 class ReloadPluginInRuntimeMojo : AbstractTeamCityMojo() {
     override fun doExecute() {
-        var doOfflineReload = false;
+        var doOfflineReload = false
         val split = teamcityVersion.split(".")
         if (split.size < 2 || split[0].toInt() < 2018 || split[1].toInt() < 2) {
-            log.info("Cannot reload plugin in runtime for TeamCity version less then 2018.2. Will perform reloadAgent. ")
+            log.info("Cannot reload plugin in runtime for TeamCity version less then 2018.2. Will reload agent side of the plugin. Restart the server to reload server side of the plugin. ")
             doOfflineReload = true
         } else if (!isPluginReloadable()) {
-            log.info("Plugin is not marked as reloadable. Will perform reloadAgent. ")
+            log.info("Plugin is not marked as reloadable. Will reload agent side of the plugin. Restart the server to reload server side of the plugin. ")
             doOfflineReload = true
         }
 

--- a/src/main/kotlin/org/jetbrains/teamcity/maven/sdk/TeamCitySDK.kt
+++ b/src/main/kotlin/org/jetbrains/teamcity/maven/sdk/TeamCitySDK.kt
@@ -94,14 +94,17 @@ public class ReloadPluginMojo() : AbstractTeamCityMojo() {
 @Mojo(name = "reload", aggregator = true)
 class ReloadPluginInRuntimeMojo : AbstractTeamCityMojo() {
     override fun doExecute() {
-        if (teamcityVersion.split(".")[0].toInt() < 2018) {
+        var doOfflineReload = false;
+        val split = teamcityVersion.split(".")
+        if (split.size < 2 || split[0].toInt() < 2018 || split[1].toInt() < 2) {
             log.info("Cannot reload plugin in runtime for TeamCity version less then 2018.2. Will perform reloadAgent. ")
-            uploadPluginAgentZip()
-            log.info("Plugin uploaded. Wait for TeamCity agent to upgrade.")
-            return
+            doOfflineReload = true
+        } else if (!isPluginReloadable()) {
+            log.info("Plugin is not marked as reloadable. Will perform reloadAgent. ")
+            doOfflineReload = true
         }
-        if (teamcityVersion.split(".")[1].toInt() < 2) {
-            log.info("Cannot reload plugin in runtime for TeamCity version less then 2018.2. Will perform reloadAgent. ")
+
+        if (doOfflineReload) {
             uploadPluginAgentZip()
             log.info("Plugin uploaded. Wait for TeamCity agent to upgrade.")
             return


### PR DESCRIPTION
Since TeamCity 2018.2 (EAP2) reloading a plugin will be possible without server restart. This pull request updates 'reload' task so that it will try to reload the plugin instantly. Old logic is moved to a new 'reloadAgent' task. 